### PR TITLE
Add bin/htmlize.py

### DIFF
--- a/bin/htmlize.py
+++ b/bin/htmlize.py
@@ -1,0 +1,72 @@
+import cgi
+import sys
+import json
+
+
+def write(lines, stream):
+    for line in lines:
+        stream.write(line + "\n")
+
+
+def heading(scheme):
+    return "<h2>{scheme}</h2>".format(
+        scheme=cgi.escape(scheme)
+    )
+
+
+def iframe(src):
+    return "<iframe src=\"{src}\"></iframe>".format(
+        src=cgi.escape(src, quote=True)
+    )
+
+
+def itemize(data):
+    for scheme, info in data.items():
+        values = []
+
+        for preset in info.get("presets", []):
+            value = preset.get("value", None)
+            if not value:
+                continue
+            values.append(value)
+
+        yield scheme, values
+
+
+def html_lines(datas):
+    yield "<!doctype>"
+    yield "<html>"
+    yield "  <head>"
+    yield "  </head>"
+    yield "  <body>"
+
+    for data in datas:
+        for scheme, srcs in itemize(data):
+            yield "    " + heading(scheme)
+
+            for src in srcs:
+                yield "    " + iframe(src)
+
+    yield "  </body>"
+    yield "</html>"
+
+
+def read_json_file(filename):
+    with open(filename, "rb") as jsonfile:
+        return json.load(jsonfile)
+
+
+def main():
+    from optparse import OptionParser
+
+    usage = "usage: %prog [options] [JSONFILE ...]"
+    parser = OptionParser(usage)
+
+    options, args = parser.parse_args()
+
+    datas = map(read_json_file, args)
+    write(html_lines(datas), sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds `bin/htmlize.py`. The script is a rudimentary tool for converting JSON files in a similar format as `web/db/handlerpresets.json` to a HTML page with embedded links for all the presets.

@ikisusi asked for this (or at least something like it) to bootstrap some new experiment.

The tool accepts 0-n JSON files and outputs the generated HTML to STDOUT, the usage pattern being:

``` console
$ python bin/htmlize.py [JSONFILE ...]
```

For example to htmlizeify the `web/db/handlerpresets.json` you would run:

``` console
$ python bin/htmlize.py web/db/handlerpresets.json
```
