### PR TITLE
Add script to validate web/db/handlerpresets.json file

### DIFF
--- a/bin/validate-presets.py
+++ b/bin/validate-presets.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+import json
+import sys
+
+
+def validate_presets(presets_file):
+    with open(presets_file) as jsonfile:
+        presets_dict = json.load(jsonfile)
+
+    for handler in presets_dict.iterkeys():
+        for entry in presets_dict.get(handler).get("presets"):
+            value = entry.get("value")
+
+            if not value.startswith(handler):
+                print "ERROR: \"{0}\" handler with \"{1}\" value".format(handler, value)
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    try:
+        validate_presets(*args)
+    except TypeError:
+        print "{0} <handlerpresets.json>".format(sys.argv[0])
+        sys.exit(1)

--- a/bin/validate-presets.py
+++ b/bin/validate-presets.py
@@ -4,22 +4,38 @@ import json
 import sys
 
 
-def validate_presets(presets_file):
+def validate_presets_file(presets_file):
     with open(presets_file) as jsonfile:
         presets_dict = json.load(jsonfile)
+    for (handler, value) in validate_presets(presets_dict):
+        print "ERROR: \"{0}\" handler with \"{1}\" value".format(handler, value)
 
+
+def validate_presets(presets_dict):
+    """
+    >>> presets = {u'handler:': {u'presets':
+    ...     [{u'description': u'description', u'value': u'handler://valid'}]}}
+    >>> validate_presets(presets)
+    []
+    >>> presets = {u'handler:': {u'presets':
+    ...     [{u'description': u'description', u'value': u'error://invalid'}]}}
+    >>> validate_presets(presets)
+    [(u'handler:', u'error://invalid')]
+    """
+    error_list = []
     for handler in presets_dict.iterkeys():
         for entry in presets_dict.get(handler).get("presets"):
             value = entry.get("value")
 
             if not value.startswith(handler):
-                print "ERROR: \"{0}\" handler with \"{1}\" value".format(handler, value)
+                error_list.append((handler, value))
+    return error_list
 
 
 if __name__ == '__main__':
     args = sys.argv[1:]
     try:
-        validate_presets(*args)
+        validate_presets_file(*args)
     except TypeError:
         print "{0} <handlerpresets.json>".format(sys.argv[0])
         sys.exit(1)


### PR DESCRIPTION
Simple validation for `web/db/handlerpresets.json` file. It prints error if handler's name is not same as beginning of value's string.

Catches problems like this in handlerpresets.json:

``` json
"slack:": {
    "presets": [
        {
            "description": "Opens man page",
            "value": "x-man-page://1/man"
        }
    ]
}
```

Exmple command line usage:

``` shell
$ ./bin/validate-presets.py web/db/handlerpresets.json
ERROR: "ms-word:" handler with "word:http://www.microsoft.com/investor/downloads/events/CreditSuisseReller.docx" value
ERROR: "slack:" handler with "x-man-page://1/man" value
ERROR: "word:" handler with "ms-word:http://www.microsoft.com/investor/downloads/events/CreditSuisseReller.docx" value
ERROR: "map:" handler with "maps://?ll=50.894967,4.341626" value
ERROR: "map:" handler with "maps://?daddr=San+Francisco&dirflg=d&t=h" value
ERROR: "map:" handler with "maps://?saddr=San+Jose&daddr=San+Francisco&dirflg=r" value
ERROR: "map:" handler with "maps://?address=1,Infinite+Loop,Cupertino,California" value
```
