### PR TITLE
Bump Python version, testing if circleci works better

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,4 @@ machine:
   post:
     - pyenv install 2.6.9
     - pyenv install pypy-5.3
-    - pyenv local 2.6.9 2.7.11 pypy-5.3
+    - pyenv local 2.6.9 2.7.12 pypy-5.3


### PR DESCRIPTION
CircleCI fails when installing wheel with python2.7.11, seems to work with 2.7.12.
